### PR TITLE
Add grok-build skill (headless Grok orchestration, cross-platform)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,12 +5,12 @@
   },
   "metadata": {
     "description": "Collection of agent skills for AI coding assistants",
-    "version": "1.1.0"
+    "version": "1.2.0"
   },
   "plugins": [
     {
       "name": "ai-skills",
-      "description": "Collection of agent skills: PostgreSQL, MySQL, MSSQL, Imagen, Azure DevOps, Apple Container, Telegram, Atlassian (Jira + Confluence), Google Workspace (Gmail, Calendar, Chat, Docs, Drive, Sheets, Slides), NotebookLM, Jules, Manus, Deep Research, Outline, ElevenLabs, Google TTS.",
+      "description": "Collection of agent skills: PostgreSQL, MySQL, MSSQL, Imagen, Azure DevOps, Apple Container, Telegram, Atlassian (Jira + Confluence), Google Workspace (Gmail, Calendar, Chat, Docs, Drive, Sheets, Slides), NotebookLM, Jules, Manus, Deep Research, Outline, ElevenLabs, Google TTS, Grok Build.",
       "source": "./",
       "skills": [
         "./skills/postgres",
@@ -34,7 +34,8 @@
         "./skills/mysql",
         "./skills/mssql",
         "./skills/atlassian",
-        "./skills/telegram"
+        "./skills/telegram",
+        "./skills/grok-build"
       ]
     }
   ]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A collection of portable skills for AI coding assistants. Works with all major A
 | [outline](skills/outline/) | Search, read, and manage Outline wiki documents |
 | [jules](skills/jules/) | Delegate coding tasks to Google Jules AI agent (async bug fixes, docs, tests, features) |
 | [manus](skills/manus/) | Delegate complex tasks to Manus AI agent (deep research, market analysis, reports) |
+| [grok-build](skills/grok-build/) | Orchestrate coding by delegating well-specified tasks to xAI's Grok Build CLI headlessly — the assistant plans, specs, dispatches, and reviews every diff |
 | [notebooklm](skills/notebooklm/) | Query and manage Google NotebookLM notebooks with persistent profile auth, source sync, batch/multi queries, and structured exports |
 | [elevenlabs](skills/elevenlabs/) | Text-to-speech narration and two-host podcast generation from documents (PDF, DOCX, MD, TXT) using ElevenLabs API |
 | [google-tts](skills/google-tts/) | Text-to-speech narration and podcast generation using Google Cloud TTS (Neural2, WaveNet, Studio voices, 40+ languages) |
@@ -223,6 +224,13 @@ export MANUS_API_KEY=your-api-key
 ```
 Get your API key from [manus.im](https://manus.im) settings. Manus excels at deep research, market analysis, product comparisons, and generating comprehensive reports with visualizations.
 
+### Grok Build
+Install xAI's Grok CLI per their docs, then authenticate:
+```bash
+grok login
+```
+Verify with `grok models`. The skill runs `grok` headlessly (`--always-approve`) and reviews every diff before committing. Works on macOS, Linux, and Windows (PowerShell).
+
 ### ElevenLabs
 ```bash
 pip install -r skills/elevenlabs/requirements.txt  # Only needed for PDF/DOCX
@@ -324,6 +332,12 @@ Once installed, skills activate automatically based on your requests. Just ask n
 - "Have Manus analyze AAPL stock with technical indicators"
 - "Delegate market research on EV charging to Manus"
 - "Ask Manus to compare AWS vs GCP vs Azure pricing"
+
+### Grok Build
+- "Use grok to implement this plan task-by-task"
+- "Have grok build the CRUD endpoints from this spec"
+- "Delegate the mechanical refactor in src/utils to grok"
+- "Execute this implementation plan with grok"
 
 ### ElevenLabs
 - "Narrate this PDF as audio"

--- a/skills/grok-build/SKILL.md
+++ b/skills/grok-build/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: grok-build
+description: "Orchestrate coding work by delegating well-specified implementation tasks to xAI's Grok Build CLI (grok) running headlessly, while the coding assistant plans, writes the task specs, reviews every diff, and owns the result. Use when user says: 'use grok', 'grok build', 'delegate to grok', 'have grok implement', 'have grok execute', 'have grok build', 'send to grok', 'execute this plan with grok'. Executes a Markdown implementation plan task-by-task, or ad-hoc tasks with an inline spec."
+license: Apache-2.0
+metadata:
+  author: sanjay3290
+  version: "1.0"
+---
+
+# Grok Build Orchestration
+
+The coding assistant is the orchestrator: it plans, writes self-contained task specs,
+dispatches them to Grok Build headlessly, reviews every diff, and owns the final result.
+Grok is the fast, cheap executor. Full CLI details and verified behaviors: `references/cli.md`.
+
+## When to delegate vs keep with the orchestrator
+
+| Delegate to Grok | Keep with the orchestrator |
+|---|---|
+| Plan tasks with clear acceptance criteria | Ambiguous requirements, architecture decisions |
+| Boilerplate, scaffolding, CRUD | Deep cross-file debugging |
+| Mechanical refactors | Security-sensitive code |
+| Test writing from clear specs | Anything touching production infrastructure |
+| UI components from mockups/specs | Tasks where writing the spec ≈ doing the work |
+
+When in doubt, keep it with the orchestrator.
+
+## Session preflight (once, before the first dispatch)
+
+1. `grok update --check --json` — if `updateAvailable` is true, run `grok update` and
+   confirm with `grok --version`.
+2. `grok models` — if it errors or reports logged out, STOP and ask the user to run
+   `grok login`.
+
+## Per-task loop (sequential — the default)
+
+1. **Spec.** Write a self-contained task file (template below) to a temp directory
+   OUTSIDE the target repo — the harness scratchpad if one is available, else the OS
+   temp dir. Never write it inside the target repo. Grok has zero conversation context:
+   no one-liner prompts, ever.
+   - POSIX: `mkdir -p "${TMPDIR:-/tmp}/grok-specs"`, then write `task.md` there.
+   - Windows (PowerShell): `New-Item -ItemType Directory -Force "$env:TEMP\grok-specs"`,
+     then write `task.md` there.
+2. **Clean state.** No uncommitted *source* changes — commit or stash first, so the
+   post-run diff is exactly Grok's work. Ignore build artifacts (`__pycache__`, `dist/`,
+   etc.); if they show in `git status`, they're usually just un-gitignored, not your
+   concern. Never dispatch on a dirty source tree.
+3. **Dispatch.**
+
+   POSIX:
+
+   ```bash
+   grok --prompt-file <task-file> \
+     --output-format json \
+     --always-approve \
+     --max-turns 30 \
+     --cwd <repo>
+   ```
+
+   Windows (PowerShell) — backtick line-continuation:
+
+   ```powershell
+   grok --prompt-file <task-file> `
+     --output-format json `
+     --always-approve `
+     --max-turns 30 `
+     --cwd <repo>
+   ```
+
+   Parse the JSON output and save `sessionId`. (`--always-approve` is required for
+   headless runs — `--permission-mode acceptEdits` silently cancels edits with no
+   interactive approver. See `references/cli.md`.) For a high-stakes task, add `--check`
+   so Grok self-verifies before you review; skip it otherwise (it ~doubles latency).
+4. **Review gate — non-negotiable.**
+   - Read the diff yourself (`git diff -- <files from the spec>` to skip artifact noise):
+     does it do the task, only the task, and match repo conventions?
+   - Run the acceptance commands from the spec.
+   - **Pass** → commit with a clear message following the repo's convention → next task.
+   - **Fail** → fix-up: `grok --resume <sessionId> -p "<specific feedback>"
+     --always-approve --output-format json`. **Max 2 fix-up rounds.** Still failing →
+     revert Grok's changes (`git checkout -- .`; `git clean -fd` for new files), do the
+     task yourself, and tell the user Grok couldn't complete it.
+
+## Task spec template
+
+```markdown
+# Task: <one-line title>
+
+## Context
+- Repo: <path> — <one line on what the project is>
+- Conventions: <test runner, formatter, a good example file to imitate>
+
+## Files
+- Modify: <path>
+- Create: <path>
+
+## Task
+<precise description of the change>
+
+## Constraints
+- Do not modify any files other than those listed above.
+- <other constraints>
+
+## Acceptance criteria
+- `<exact command>` <expected result>
+```
+
+## Executing a Markdown implementation plan
+
+- One plan task per dispatch, in order.
+- Check off the plan's task checkboxes (`- [ ]` → `- [x]`) as each task lands and passes
+  the review gate.
+- If the plan explicitly marks tasks as independent, see Parallel dispatch below;
+  otherwise stay sequential.
+
+## Parallel dispatch (opt-in exception, not the default)
+
+Only when a plan explicitly marks tasks independent: dispatch each with
+`--worktree=<task-slug>`, run concurrently, then review and merge one worktree at a
+time through the same review gate. Merge conflicts usually eat the savings — prefer
+sequential.
+
+## Failure handling
+
+| Failure | Action |
+|---|---|
+| `stopReason: "Cancelled"`, empty text, no diff | Missing `--always-approve` — retry with it |
+| CLI error / timeout | Retry once; then do the task yourself and note the fallback |
+| Auth expired | Stop; ask the user to run `grok login` |
+| 2 fix-up rounds exhausted | Revert Grok's diff; the orchestrator finishes the task |
+| Dirty tree at dispatch | Refuse; commit/stash first |
+
+## Models
+
+Default `grok-4.5`. Add `-m grok-composer-2.5-fast` only for trivial mechanical tasks.

--- a/skills/grok-build/references/cli.md
+++ b/skills/grok-build/references/cli.md
@@ -1,0 +1,99 @@
+# Grok Build CLI — headless reference
+
+Verified against `grok` 0.2.93 (stable channel), 2026-07-09. Re-verify with
+`grok --help` after major version bumps — flags mirror Claude Code's.
+
+## One-shot headless run
+
+```bash
+grok -p "prompt" --output-format json
+grok --prompt-file task.md --output-format json   # preferred: no shell-quoting issues
+```
+
+⚠️ `grok agent` is NOT a one-shot command — it runs the agent as a stdio/WebSocket
+server for SDK/ACP integrations. Always use top-level `grok -p` / `--prompt-file`.
+
+## JSON output shape (verified)
+
+```json
+{
+  "text": "final response text",
+  "stopReason": "EndTurn",
+  "sessionId": "019f470d-3e02-7601-b726-1133cc72ef76",
+  "requestId": "…",
+  "thought": "…"
+}
+```
+
+`sessionId` is the handle for fix-ups.
+
+- POSIX: `grok --prompt-file task.md --output-format json | python3 -c "import json,sys;print(json.load(sys.stdin)['sessionId'])"`
+- Windows (PowerShell): `grok --prompt-file task.md --output-format json | ConvertFrom-Json | Select-Object -ExpandProperty sessionId`
+
+`stopReason: "Cancelled"` with empty `text` means a tool call hit a permission gate and
+was auto-cancelled headlessly — you forgot `--always-approve` (see below).
+
+## Permissions — the headless gotcha
+
+**Use `--always-approve` for headless dispatch. Do NOT rely on
+`--permission-mode acceptEdits`.**
+
+Verified 2026-07-09: `--permission-mode acceptEdits` FAILS headlessly — the edit tool
+hits a permission gate with no interactive approver, and the run returns
+`stopReason: "Cancelled"` with no file change. `--always-approve` auto-approves BOTH
+edits AND shell commands in one flag (Grok ran the acceptance test itself in the same
+run). This is safe in the grok-build workflow because dispatch happens on a clean tree,
+the task spec constrains scope, and the orchestrator reviews the full diff before
+committing.
+
+Optional hardening: `--sandbox <profile>` (env `GROK_SANDBOX`) restricts filesystem and
+network access — layer it on for untrusted repos.
+
+## Resume / fix-up
+
+```bash
+grok --resume <sessionId> -p "specific feedback" --always-approve --output-format json
+```
+
+Verified: the resumed session retains full context — it knows the repo and files touched
+without re-explanation. Pass only the specific feedback, not the whole task again.
+
+## Self-verification (`--check`) — opt-in only
+
+`--check` appends a self-verification loop: Grok spawns a verifier subagent that emits a
+checklist, action trace, scope/edge-case evaluation, and its own `VERDICT: PASS`.
+
+Verified: correct but ~doubles wall-clock (a trivial task went from a few seconds to
+~48s) and adds token cost, undercutting Grok's speed/cost advantage. Skip it by default —
+the orchestrator's review gate is the authority. Add `--check` only for high-stakes tasks
+where you want Grok to self-correct before review.
+
+## Update check (session preflight)
+
+```bash
+grok update --check --json
+# → {"currentVersion":"0.2.93","latestVersion":"0.2.93","updateAvailable":false,"channel":"stable",…}
+grok update        # installs latest stable
+```
+
+## Key flags
+
+| Flag | Purpose |
+|---|---|
+| `--always-approve` | Auto-approve all tool executions (edits + shell). **Required for headless.** |
+| `--permission-mode <m>` | `default`, `acceptEdits`, `auto`, `dontAsk`, `bypassPermissions`, `plan` — but see gotcha above |
+| `--allow` / `--deny` | Fine-grained permission rules (Claude Code `--allowedTools` syntax) |
+| `--max-turns <N>` | Turn cap — always set for headless runs |
+| `--check` | Appends a self-verification loop (opt-in; see above) |
+| `--worktree[=name]` | Run in a fresh git worktree (parallel tasks) |
+| `--json-schema '<schema>'` | Constrain final output to a JSON Schema |
+| `-m <model>` | `grok-4.5` (default) or `grok-composer-2.5-fast` |
+| `--cwd <dir>` | Working directory for the run |
+| `--best-of-n <N>` | Run N ways in parallel, pick best (headless) |
+
+## Install & auth
+
+- Install / update: follow xAI's Grok CLI install docs for your OS; verify with
+  `grok --version`. Works on macOS, Linux, and Windows (PowerShell).
+- Auth: grok.com subscription OAuth (`grok login` / `grok logout`). Check with `grok models`.
+- Models available: `grok-4.5` (default), `grok-composer-2.5-fast`.


### PR DESCRIPTION
## Summary

Adds a **grok-build** skill: orchestrate coding by delegating well-specified implementation tasks to xAI's Grok Build CLI (`grok`) running headlessly, while the coding assistant plans, writes the task specs, reviews every diff, and owns the result.

Ported from a personal skill and generalized for the marketplace:
- **Harness-neutral** — "the coding assistant (orchestrator)" instead of assuming a specific assistant; works across Claude Code, Gemini CLI, Cursor, Codex, Goose, Antigravity.
- **Cross-platform** — POSIX + Windows/PowerShell equivalents for every command (dispatch, temp-dir creation, JSON `sessionId` parsing via `ConvertFrom-Json`).
- **Generic plan execution** — executes any Markdown implementation plan task-by-task (checkbox tracking), with no dependency on any private tooling.

## What's included

- `skills/grok-build/SKILL.md` — orchestration workflow: when to delegate, session preflight, per-task dispatch loop, non-negotiable review gate, resume-based fix-ups (max 2 rounds), failure-handling table, models.
- `skills/grok-build/references/cli.md` — verified CLI reference (grok 0.2.93): the `--always-approve` headless gotcha, JSON output shape, resume, `--check`, flags table, install/auth.
- Registered in `.claude-plugin/marketplace.json` (version 1.1.0 → 1.2.0).
- Documented in `README.md` (skills table, Setup, example prompts).

## Notes

The core value is the verified headless behavior: `--always-approve` is required for headless dispatch — `--permission-mode acceptEdits` silently cancels edits with no interactive approver. The skill enforces a clean-tree precondition and a mandatory diff review before every commit.
