### PR TITLE
Add whatsapp skill (pywhats linked-device client)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "ai-skills",
-      "description": "Collection of agent skills: PostgreSQL, MySQL, MSSQL, Imagen, Azure DevOps, Apple Container, Telegram, Atlassian (Jira + Confluence), Google Workspace (Gmail, Calendar, Chat, Docs, Drive, Sheets, Slides), NotebookLM, Jules, Manus, Deep Research, Outline, ElevenLabs, Google TTS, Grok Build.",
+      "description": "Collection of agent skills: PostgreSQL, MySQL, MSSQL, Imagen, Azure DevOps, Apple Container, Telegram, Atlassian (Jira + Confluence), Google Workspace (Gmail, Calendar, Chat, Docs, Drive, Sheets, Slides), NotebookLM, Jules, Manus, Deep Research, Outline, ElevenLabs, Google TTS, Grok Build, WhatsApp (pywhats).",
       "source": "./",
       "skills": [
         "./skills/postgres",
@@ -35,7 +35,8 @@
         "./skills/mssql",
         "./skills/atlassian",
         "./skills/telegram",
-        "./skills/grok-build"
+        "./skills/grok-build",
+        "./skills/whatsapp"
       ]
     }
   ]

--- a/skills/whatsapp/README.md
+++ b/skills/whatsapp/README.md
@@ -1,0 +1,150 @@
+# WhatsApp Skill (pywhats)
+
+An AI agent skill for sending and receiving WhatsApp messages via the
+**unofficial** linked-device client [`pywhats`](https://pypi.org/project/pywhats/)
+— pair with a QR code, send text and images, message groups, mark read, set
+presence/typing, and stream inbound events as JSON lines. Works with Claude
+Code, Gemini CLI, Cursor, OpenAI Codex, Goose, and other AI clients supporting
+the [Agent Skills Standard](https://agentskills.io).
+
+> **Not** the official WhatsApp Business / Cloud API. This links as a companion
+> device (like WhatsApp Web) to a personal WhatsApp account.
+
+## Features
+
+- **Pair** — One-time QR link; ASCII QR printed in the terminal
+- **Send text / image** — 1:1 chats; images: jpg/png/webp up to 16MB
+- **Groups** — Fetch metadata (JSON) and send group text
+- **Receipts** — Blue-tick messages (`mark-read`); optional auto-read in `listen`
+- **Presence / typing** — Global available/unavailable; composing/paused/recording
+- **Listen** — Long-running JSONL event stream for every pywhats event
+- **Managed venv** — Auto-creates `$PYWHATS_HOME/venv` and installs `pywhats` on first run
+
+## Requirements
+
+- Python 3.11+
+- `bash` (for the bootstrap script)
+- Network access to WhatsApp + PyPI on first bootstrap
+- A phone with WhatsApp to scan the pair QR
+
+## Caveats
+
+`pywhats` is a young library (0.1.x, text/image only) and an **unofficial**
+client. Automating a personal account can violate WhatsApp's ToS and risk a
+ban — use a personal/test number, not production.
+
+In testing we found WhatsApp sometimes removes freshly linked devices within
+a minute or so if the account has seen rapid pair/unpair cycles. The `pair`
+command detects this and prints recovery steps (remove linked devices on the
+phone, wait ~15–20 minutes, pair once).
+
+## Quick Start
+
+### 1. Pair a device
+
+```bash
+skills/whatsapp/scripts/wa.py pair
+```
+
+On first run this will:
+
+1. Create `$HOME/.pywhats/venv` (or `$PYWHATS_HOME/venv`), streaming progress
+2. `pip install "pywhats>=0.1.1,<0.2"`
+3. Print an ASCII QR code (also saved as `<session>.qr.png` for terminals
+   where the ASCII render isn't scannable)
+
+On your phone: **WhatsApp → Linked Devices → Link a Device** and scan the QR.
+When pairing succeeds the CLI prints the device JID, waits briefly for history
+sync, saves the session, and exits.
+
+Re-running `pair` on an already-paired session is a no-op (exits 0).
+
+### 2. Send a message
+
+```bash
+skills/whatsapp/scripts/wa.py send-text 15550001234 "hello from the skill"
+skills/whatsapp/scripts/wa.py send-image 15550001234 ./photo.jpg --caption "hi"
+```
+
+`<to>` accepts a bare international number without `+`, or a full JID
+(`...@s.whatsapp.net` / `...@g.us`).
+
+### 3. Listen for events
+
+```bash
+skills/whatsapp/scripts/wa.py listen --read
+# one JSON object per line, e.g.
+# {"event":"message","id":"...","chat":"...","text":"hi",...}
+```
+
+## Command Reference
+
+| Command | Description | Key options |
+|---------|-------------|-------------|
+| `pair` | Link a new companion device (ASCII QR) | `--session NAME` |
+| `send-text <to> <text>` | Send 1:1 text; prints message id | `--session` |
+| `send-image <to> <path>` | Send image; prints message id | `--caption`, `--session` |
+| `group-info <gid>` | Group metadata as JSON | `--session` |
+| `group-send <gid> <text>` | Group text (resolves participants) | `--session` |
+| `mark-read <chat> <ids...>` | Blue-tick message ids | `--sender` (groups), `--session` |
+| `presence <available\|unavailable>` | Global presence | `--session` |
+| `typing <to> <composing\|paused>` | Chat presence / typing | `--media audio`, `--session` |
+| `listen` | Stream events as JSON lines until Ctrl-C | `--read`, `--subscribe JID` (presence), `--events LIST`, `--session` |
+
+Global options (go **before** the subcommand, e.g. `wa.py --session work pair`):
+
+- `--session NAME` — session file `$PYWHATS_HOME/<NAME>.session` (default
+  `default`, or env `PYWHATS_SESSION`)
+
+Presence events only flow after subscribing: `wa.py listen --subscribe 15550001234
+--events presence` (this also marks the linked device "available").
+
+Exit codes: `0` success, `1` error / unpaired / logged out, `2` usage error,
+`130` interrupted (Ctrl-C).
+
+## Runtime layout
+
+| Path | Purpose |
+|------|---------|
+| `$PYWHATS_HOME` | Default `$HOME/.pywhats` |
+| `$PYWHATS_HOME/venv` | Managed Python venv with `pywhats` |
+| `$PYWHATS_HOME/<NAME>.session` | Pairing credentials |
+| `$PYWHATS_HOME/<NAME>.session.signal.db` | Signal ratchet / keys |
+
+Bootstrap script: `scripts/_bootstrap.sh` — creates the venv if needed, ensures
+`pywhats` + `qrcode` are importable, prints the absolute path to the venv
+python as its last stdout line. `wa.py` re-execs under that interpreter when
+started with a system `python3` that lacks pywhats.
+
+## Multi-account
+
+```bash
+wa.py --session personal pair
+wa.py --session work pair
+wa.py --session work send-text 15550001234 "from work session"
+export PYWHATS_SESSION=work   # default for subsequent commands
+```
+
+## Claude Code / agent usage
+
+When the agent needs to message you on WhatsApp:
+
+```bash
+# after a one-time pair
+skills/whatsapp/scripts/wa.py send-text "$MY_PHONE" "Deploy finished ✅"
+```
+
+For full method/event docs when writing custom Python against pywhats, see
+[references/api.md](references/api.md).
+
+## Security notes
+
+- A paired session file is equivalent to a logged-in WhatsApp Web session —
+  protect `$PYWHATS_HOME` (filesystem permissions, backups).
+- `pywhats` is an unofficial reimplementation of the protocol — do not rely
+  on it for sensitive traffic.
+- Prefer a secondary/test WhatsApp number for automation.
+
+## License
+
+Apache 2.0 (skill packaging). `pywhats` is separately licensed on PyPI.

--- a/skills/whatsapp/SKILL.md
+++ b/skills/whatsapp/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: whatsapp
+description: "Send and receive WhatsApp messages via the unofficial linked-device client pywhats (pip install pywhats) — pair with QR, send text/images, group chat, read receipts, presence/typing, and a long-running JSON event stream. Use when the user wants to script WhatsApp as a linked companion device (like WhatsApp Web), pair a device, send a WhatsApp from Python, or listen for inbound messages. Triggers: 'whatsapp', 'send whatsapp', 'pair whatsapp', 'pywhats', 'linked device', 'whatsapp web client'. NOT the official WhatsApp Business/Cloud API."
+---
+
+# WhatsApp (pywhats)
+
+Drive a WhatsApp account as a **linked companion device** (like WhatsApp Web)
+from async Python via [`pywhats`](https://pypi.org/project/pywhats/) (pre-alpha,
+text/image only). This is an **unofficial** multi-device client — **not** the
+official WhatsApp Business / Cloud API.
+
+CLI entrypoint: `scripts/wa.py` (auto-bootstraps a managed venv on first run).
+
+## Mental model
+
+- **Pairing = one-time QR scan.** `wa.py pair` shows an ASCII QR; scan it in
+  WhatsApp → Linked Devices. Credentials persist to
+  `$PYWHATS_HOME/<session>.session` (+ `.signal.db`).
+- **Resuming = silent.** Later commands reconnect with the same session — no QR.
+- **JIDs address chats.** Bare phone `15550001234` → `15550001234@s.whatsapp.net`;
+  groups use `...@g.us`.
+- **Events are how you receive.** `wa.py listen` prints one JSON object per event.
+
+## ⚠️ Never bare-await Client calls inside a handler
+
+Event handlers run **inline on the receive loop**. Awaiting `send_*`,
+`mark_read`, `get_group_info`, `download_media`, etc. inside a handler
+**deadlocks** the connection. Always `asyncio.create_task(...)`. The `listen`
+subcommand already does this for `--read`.
+
+## Commands
+
+```bash
+scripts/wa.py pair                                          # one-time QR pair
+scripts/wa.py send-text 15550001234 "hello"                 # 1:1 text
+scripts/wa.py send-image 15550001234 photo.jpg --caption hi # 1:1 image
+scripts/wa.py group-info 120363000000000000@g.us            # group metadata JSON
+scripts/wa.py group-send 120363000000000000@g.us "hi all"   # group text
+scripts/wa.py mark-read 15550001234 MSGID [--sender JID]    # blue ticks
+scripts/wa.py presence available                            # global presence
+scripts/wa.py typing 15550001234 composing [--media audio]  # typing indicator
+scripts/wa.py listen --read --events message,receipt        # JSONL event stream
+scripts/wa.py --session work send-text 15550001234 "hi"     # named session
+```
+
+| Command | Behavior |
+|---------|----------|
+| `pair` | Fresh link via ASCII QR; idempotent if already paired |
+| `send-text <to> <text>` | Send 1:1 text; print message id |
+| `send-image <to> <path> [--caption C]` | Send image (jpg/png/webp, ≤16MB); print id |
+| `group-info <gid>` | Print group JSON (subject, owner, participants, …) |
+| `group-send <gid> <text>` | Resolve members then send group text; print id |
+| `mark-read <chat> <ids...>` | Blue-tick; `--sender` for groups |
+| `presence <available\|unavailable>` | Global presence |
+| `typing <to> <composing\|paused>` | Chat presence; optional `--media audio` |
+| `listen` | Long-running JSON lines; `--read`, `--events`, `--subscribe JID` (required for presence events) |
+
+Global: `--session NAME` (default `default`, or env `PYWHATS_SESSION`) —
+goes **before** the subcommand: `wa.py --session work pair`.
+
+## Sessions / multi-account
+
+```
+$PYWHATS_HOME/                 # default: ~/.pywhats
+  venv/                        # managed Python + pywhats
+  default.session              # --session default
+  default.session.signal.db
+  work.session                 # --session work
+```
+
+Override home with `PYWHATS_HOME`. Unpaired / logged-out sessions print a clear
+message to re-run `wa.py --session <name> pair`.
+
+If `pair` reports the device was logged out right after scanning, that is
+WhatsApp device-churn reaping, not a failure of the skill — the dead session is
+deleted automatically; follow the recovery steps it prints (remove linked
+devices, wait 15–20 min, pair once).
+
+## Full reference
+
+[references/api.md](references/api.md) — every `Client` method, every event
+payload, JID construction, and the `download_media` note.

--- a/skills/whatsapp/references/api.md
+++ b/skills/whatsapp/references/api.md
@@ -1,0 +1,261 @@
+# pywhats API reference
+
+Import surface, methods, events, and worked examples for the unofficial
+WhatsApp multi-device client (`pip install pywhats`, version `0.1.x`).
+
+This skill manages a venv at `$PYWHATS_HOME/venv` (default `~/.pywhats/venv`).
+Prefer the skill CLI for day-to-day use:
+
+```bash
+skills/whatsapp/scripts/wa.py pair
+skills/whatsapp/scripts/wa.py send-text 15550001234 "hello"
+```
+
+Or run your own scripts with the managed interpreter:
+
+```bash
+# print interpreter path (creates venv + installs pywhats on first run)
+PY=$(bash skills/whatsapp/scripts/_bootstrap.sh)
+"$PY" your_script.py
+# or: "$HOME/.pywhats/venv/bin/python" your_script.py
+# PYWHATS_HOME defaults to $HOME/.pywhats
+```
+
+## Contents
+- Imports & JIDs
+- Client constructor
+- Client methods (send/receive/groups/receipts/presence/media)
+- Events & payloads
+- Worked examples
+- Errors
+
+## Imports & JIDs
+
+```python
+from pywhats import Client
+from pywhats.binary.jid import parse_jid, jid_to_str
+
+peer  = parse_jid("15550001234@s.whatsapp.net")   # a person: country code + number
+group = parse_jid("120363000000000000@g.us")      # a group
+```
+
+A `JID` is `user` / `server` / `device`. `s.whatsapp.net` = person (PN),
+`g.us` = group, `lid` = the newer "linked ID" addressing (inbound senders
+often appear as `<n>@lid` — just compare/echo them, no manual construction
+needed).
+
+Bare phone numbers (international format, no `+`) are normalized by the
+skill CLI to `<number>@s.whatsapp.net` before `parse_jid`.
+
+## Client constructor
+
+```python
+Client(
+    session_path: str | None = None,   # file to persist pairing + Signal keys; None = ephemeral
+    *,
+    ws_url: str | None = None,         # override the WhatsApp WS endpoint (tests only)
+    media_http_get=None,               # inject an HTTP GET for media (defaults to stdlib urllib)
+    media_http_post=None,              # inject an HTTP POST for media upload
+)
+```
+
+`session_path="x.session"` also creates `x.session.signal.db` alongside it.
+Same path on the next run ⇒ silent login-resume (no QR).
+
+The skill stores sessions at `$PYWHATS_HOME/<NAME>.session`
+(default `~/.pywhats/default.session`).
+
+## Client methods
+
+All are `async`. Connection lifecycle:
+
+| Method | Purpose |
+|---|---|
+| `await client.connect()` | Open WS, run handshake, pair (fresh) or resume (saved session). |
+| `await client.wait_closed()` | Block until the connection closes. |
+| `await client.disconnect()` | Close cleanly. |
+| `client.on(event)` | Decorator registering an **async** handler (see Events). |
+| `client.device` | The `DeviceStore` (has `.jid` once paired). |
+
+Messaging (call these from the **main coroutine**, or via
+`asyncio.create_task` inside a handler — never bare `await` inside a handler):
+
+| Method | Signature | Notes |
+|---|---|---|
+| Send text | `send_text(chat: JID, text: str) -> Message` | 1:1 or any chat JID. |
+| Send image | `send_image(chat, image_bytes, *, mimetype="image/jpeg", caption="", width=0, height=0) -> Message` | Encrypts + uploads to CDN, sends `ImageMessage`. |
+| Send to group | `send_group_text(group: JID, text: str, participants: list[JID]) -> Message` | Pass the member JIDs (get them from `get_group_info`). |
+| Group metadata | `get_group_info(group: JID) -> GroupInfo` | Participants + admin ranks over `w:g2`. |
+| Mark read | `mark_read(chat: JID, message_ids: list[str], *, sender: JID \| None = None) -> None` | `sender` = participant for group receipts. |
+| Global presence | `send_presence(state: str) -> None` | `state`: `"available"` / `"unavailable"`. |
+| Subscribe presence | `subscribe_presence(jid: JID) -> None` | Then you get `presence` events for that peer. |
+| Typing indicator | `send_chat_presence(jid: JID, state: str, *, media: str \| None = None) -> None` | `state`: `"composing"` / `"paused"`; `media="audio"` for recording. |
+| Download media | `download_media(info) -> bytes` | Decrypts an inbound attachment described by a `MediaInfo` (`direct_path`, `media_key`, integrity hashes, `media_type`). Requires an active connection. |
+
+`send_*` block until the server ACKs and return a `Message`. `get_group_info`
+and `download_media` block on a server/CDN round-trip — this is exactly why
+they deadlock if awaited inside an event handler.
+
+### MediaInfo (inbound download)
+
+```python
+from pywhats.media import MediaInfo  # or pywhats.media.download.MediaInfo
+
+# Fields used by download_media:
+#   direct_path: str
+#   media_key: bytes          # 32-byte key
+#   file_sha256: bytes
+#   file_enc_sha256: bytes
+#   media_type: str           # e.g. WhatsApp Image Keys constant
+#   mms_type: str = ""        # optional CDN type hint
+```
+
+**Limitation (pywhats 0.1.x):** the live `message` event is **text-only** —
+its `Message` payload has just `id, chat, sender, text, timestamp, from_me`
+and carries **no** media descriptor, so inbound attachments cannot currently
+be auto-downloaded from a `message` event (the `wa.py listen` subcommand does
+not attempt it). `download_media(info)` works only if you obtain a
+`MediaInfo` by other means; remember to call it via `create_task`, never
+bare-`await`, inside a handler.
+
+## Events & payloads
+
+Register with `@client.on("<name>")` on an **async** function. Payload is a
+slotted dataclass (fields below).
+
+| Event | Payload | Fields |
+|---|---|---|
+| `qr` | `str` | the QR text (render/scan it) |
+| `paired` | `JID` | our device JID after a fresh link |
+| `connected` | *(none)* | login/resume succeeded |
+| `message` | `Message` | `id, chat, sender, text, timestamp, from_me` (group msg ⇒ `chat.server=="g.us"`, `sender` = participant) |
+| `receipt` | `Receipt` | `from_jid, message_ids, type, timestamp, participant` (`type==""` grey/delivered, `"read"` blue) |
+| `presence` | `Presence` | `from_jid, unavailable, last_seen` |
+| `chat_presence` | `ChatPresence` | `from_jid, state, media` (typing/recording) |
+| `history_sync` | `HistorySync` | `sync_type, progress, chunk_order, conversation_count, message_count, conversation_ids, pushnames` |
+| `mute` | `Mute` | `jid, muted, mute_end_timestamp, timestamp` |
+| `pin` | `Pin` | `jid, pinned, timestamp` |
+| `archive` | `Archive` | `jid, archived, timestamp` |
+| `contact` | `Contact` | `jid, first_name, full_name, timestamp` |
+| `pushname` | `PushName` | `name, timestamp` |
+| `decrypt_error` | `(message_id: str, reason: str)` | a message failed to decrypt |
+| `logged_out` | `reason: str` | server rejected/removed the device (401) |
+| `disconnected` | *(none)* | connection closed |
+
+`GroupInfo`: `jid, subject, owner, participants, announce, locked`.
+`GroupParticipant`: `jid, is_admin, is_super_admin`.
+
+## ⚠️ Never bare-await Client calls inside a handler
+
+Event handlers run **inline on the receive loop**. Awaiting a Client method
+that waits on a server reply deadlocks the connection. Always:
+
+```python
+asyncio.create_task(client.send_text(msg.chat, "pong"))   # ✅
+# await client.send_text(...)                             # ❌ deadlock
+```
+
+Awaiting from the main coroutine (outside any handler) is fine.
+
+## Worked examples
+
+### Send an image after connecting
+
+```python
+import asyncio
+from pathlib import Path
+from pywhats import Client
+from pywhats.binary.jid import parse_jid
+
+async def main():
+    # Session path — skill default is ~/.pywhats/default.session
+    client = Client(session_path="wa.session")
+
+    @client.on("qr")                      # only fires if not yet paired
+    async def on_qr(qr):
+        print("scan:\n", qr)
+
+    await client.connect()
+    img = Path("photo.jpg").read_bytes()
+    msg = await client.send_image(parse_jid("15550001234@s.whatsapp.net"),
+                                  img, mimetype="image/jpeg", caption="hi")
+    print("sent", msg.id)
+    await client.disconnect()
+
+asyncio.run(main())
+```
+
+Every handler **must be an async function** — `Client._emit` awaits each one,
+so a plain lambda/sync function raises `TypeError` on every event. Handlers
+that only print are fine as `async def`; only handlers that await server
+round-trips need `create_task`.
+
+### Receive + reply in a group (handler dispatches off-loop)
+
+```python
+@client.on("message")
+async def on_message(msg):
+    if msg.chat.server != "g.us":
+        return
+    print("group msg:", msg.text, "from", msg.sender)
+
+    async def reply():
+        info = await client.get_group_info(msg.chat)          # safe: we're in a task
+        members = [p.jid for p in info.participants]
+        await client.send_group_text(msg.chat, "got it", members)
+    asyncio.create_task(reply())
+```
+
+### Read receipts + presence
+
+```python
+@client.on("message")
+async def _(msg):
+    # sender/participant is group-receipt semantics only — pass None for 1:1.
+    sender = msg.sender if msg.chat.server == "g.us" else None
+    asyncio.create_task(client.mark_read(msg.chat, [msg.id], sender=sender))
+
+# from the main coroutine:
+await client.send_presence("available")
+await client.subscribe_presence(parse_jid("15550001234@s.whatsapp.net"))
+await client.send_chat_presence(peer, "composing")   # "typing…"
+```
+
+### History sync (only on a FRESH pair)
+
+```python
+@client.on("history_sync")
+async def _(ev):
+    print(ev.sync_type, ev.conversation_count, "chats,", ev.message_count, "msgs")
+```
+
+The four bootstrap blobs (`INITIAL_BOOTSTRAP`, `INITIAL_STATUS_V3`,
+`NON_BLOCKING_DATA`, `PUSH_NAME`) arrive within a few seconds of a *fresh*
+link and are downloaded/decrypted automatically. They do **not** re-arrive
+on a resume.
+
+### Skill CLI equivalents
+
+`--session NAME` is a global option and goes **before** the subcommand
+(e.g. `wa.py --session work pair`).
+
+| Goal | Command |
+|---|---|
+| Pair | `wa.py [--session NAME] pair` |
+| Send text | `wa.py send-text <to> <text>` |
+| Send image | `wa.py send-image <to> <path> [--caption C]` (jpg/png/webp, ≤16MB) |
+| Group info | `wa.py group-info <gid>` |
+| Group send | `wa.py group-send <gid> <text>` |
+| Mark read | `wa.py mark-read <chat> <ids...> [--sender JID]` |
+| Presence | `wa.py presence available\|unavailable` |
+| Typing | `wa.py typing <to> composing\|paused [--media audio]` |
+| Listen (JSONL) | `wa.py listen [--read] [--subscribe JID …] [--events LIST]` — presence events require `--subscribe` |
+
+## Errors
+
+- `pywhats.errors.NotConnected` — called a send before `connect()`.
+- `pywhats.errors.PairingFailed` — the QR window expired; reconnect to get a
+  fresh QR (loop `connect()` on this exception).
+- `logged_out` event with reason `401` — device unlinked or reaped (often
+  device churn; remove linked devices, wait ~15–20 min, re-pair once).
+  Requires pywhats >= 0.1.1, which the skill pins.

--- a/skills/whatsapp/scripts/_bootstrap.sh
+++ b/skills/whatsapp/scripts/_bootstrap.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Managed venv for pywhats. Run standalone (do not source — ends with exit):
+#   PY=$(bash skills/whatsapp/scripts/_bootstrap.sh)
+# Final stdout line is the absolute path to the venv's python interpreter.
+# Idempotent: skips venv/pip work when pywhats is already importable.
+set -euo pipefail
+
+PYWHATS_HOME="${PYWHATS_HOME:-$HOME/.pywhats}"
+VENV_DIR="${PYWHATS_HOME}/venv"
+PYTHON=""
+
+die() {
+  printf '%s\n' "$*" >&2
+  exit 1
+}
+
+# pywhats needs Python >= 3.11. The platform default `python3` is often older
+# (macOS ships 3.9), so pick a suitable interpreter to build the venv from.
+_is_py311() {
+  "$1" -c 'import sys; sys.exit(0 if sys.version_info[:2] >= (3, 11) else 1)' 2>/dev/null
+}
+
+find_base_py() {
+  cand=""
+  for cand in python3.13 python3.12 python3.11 python3.14 python3 python; do
+    command -v "${cand}" >/dev/null 2>&1 || continue
+    if _is_py311 "${cand}"; then
+      command -v "${cand}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Prefer an existing venv interpreter.
+if [ -x "${VENV_DIR}/bin/python" ]; then
+  PYTHON="${VENV_DIR}/bin/python"
+elif [ -x "${VENV_DIR}/bin/python3" ]; then
+  PYTHON="${VENV_DIR}/bin/python3"
+fi
+
+# A pre-existing venv on the wrong Python is unusable for pywhats — say so clearly
+# rather than failing later with a cryptic pip "no matching version" error.
+if [ -n "${PYTHON}" ] && ! _is_py311 "${PYTHON}"; then
+  die "error: venv at ${VENV_DIR} uses $("${PYTHON}" -V 2>&1), but pywhats needs Python >= 3.11. Remove that directory and re-run."
+fi
+
+if [ -z "${PYTHON}" ]; then
+  BASE_PY="$(find_base_py)" || die "error: need Python >= 3.11 for pywhats, but none found on PATH (looked for python3.13/3.12/3.11/python3). Install Python 3.11+ and retry."
+  mkdir -p "${PYWHATS_HOME}"
+  "${BASE_PY}" -m venv "${VENV_DIR}" || die "error: failed to create venv at ${VENV_DIR}"
+  if [ -x "${VENV_DIR}/bin/python" ]; then
+    PYTHON="${VENV_DIR}/bin/python"
+  else
+    PYTHON="${VENV_DIR}/bin/python3"
+  fi
+  [ -x "${PYTHON}" ] || die "error: venv python missing after create: ${VENV_DIR}"
+fi
+
+# Ensure pywhats >= 0.1.1 (oldest version with the logout events the CLI
+# relies on) and qrcode are importable; install/upgrade only when the probe fails.
+PROBE='import sys, pywhats, qrcode; v=tuple(int(x) for x in pywhats.__version__.split(".")[:3]); sys.exit(0 if v >= (0, 1, 1) else 1)'
+if ! "${PYTHON}" -c "${PROBE}" >/dev/null 2>&1; then
+  "${PYTHON}" -m pip install --upgrade pip >/dev/null 2>&1 \
+    || die "error: pip upgrade failed in ${VENV_DIR}"
+  # Progress → stderr so stdout stays pure (final line must be the interpreter path).
+  "${PYTHON}" -m pip install --upgrade "pywhats>=0.1.1,<0.2" "qrcode[pil]>=7.4" >&2 \
+    || die "error: failed to install pywhats into ${VENV_DIR}"
+  "${PYTHON}" -c "${PROBE}" >/dev/null 2>&1 \
+    || die "error: pywhats>=0.1.1/qrcode still not importable after install"
+fi
+
+# Absolute path WITHOUT resolving the binary symlink. Venv `bin/python` is
+# often a symlink to the system interpreter; following it would re-exec outside
+# the venv and lose site-packages (and loop with wa.py's bootstrap).
+case "${PYTHON}" in
+  /*) ;;
+  *)
+    _dir="$(cd "$(dirname "${PYTHON}")" && pwd)"
+    PYTHON="${_dir}/$(basename "${PYTHON}")"
+    ;;
+esac
+
+printf '%s\n' "${PYTHON}"
+# Always exit when executed as a script. (Do not `source` this file.)
+exit 0

--- a/skills/whatsapp/scripts/wa.py
+++ b/skills/whatsapp/scripts/wa.py
@@ -1,0 +1,753 @@
+#!/usr/bin/env python3
+"""WhatsApp CLI dispatcher powered by the pywhats linked-device client.
+
+Portable launcher: if ``pywhats`` (or ``qrcode``) is not importable under the
+current interpreter, this script re-executes itself under the managed venv at
+``$PYWHATS_HOME/venv`` (default ``~/.pywhats/venv``), building it first via
+``_bootstrap.sh`` when needed. Calling ``python3 wa.py ...`` therefore works
+on a fresh machine without a manual venv activate step. Bootstrap progress
+streams to stderr so a first run is visibly installing, not hung.
+
+Usage examples (after first pair)::
+
+    wa.py pair
+    wa.py send-text 15550001234 "hello"
+    wa.py listen --read
+    wa.py --session work send-text 15550001234 "hi"   # named session
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Bootstrap re-exec: ensure we are running under the managed pywhats venv.
+# Staged via _WA_BOOTSTRAP_STAGE to guarantee termination:
+#   stage 0 → blind execv into an existing venv python (fast path, no subprocess)
+#   stage 1 → run _bootstrap.sh (creates/repairs the venv), execv its interpreter
+#   stage 2 → still broken after bootstrap: hard error
+# ---------------------------------------------------------------------------
+import os
+import pathlib
+import subprocess
+import sys
+
+
+def _ensure_pywhats() -> None:
+    try:
+        import pywhats  # noqa: F401
+        import qrcode  # noqa: F401  (ASCII QR for `pair`; guaranteed in the venv)
+
+        return
+    except ImportError:
+        pass
+
+    stage = os.environ.get("_WA_BOOTSTRAP_STAGE", "0")
+    home = pathlib.Path(os.environ.get("PYWHATS_HOME", pathlib.Path.home() / ".pywhats"))
+    venv_python = home / "venv" / "bin" / "python"
+    script = os.path.abspath(__file__)
+
+    if stage == "0" and venv_python.is_file():
+        os.environ["_WA_BOOTSTRAP_STAGE"] = "1"
+        os.execv(str(venv_python), [str(venv_python), script, *sys.argv[1:]])
+
+    if stage in ("0", "1"):
+        bootstrap = os.path.join(os.path.dirname(script), "_bootstrap.sh")
+        if not os.path.isfile(bootstrap):
+            print(f"error: pywhats not installed and bootstrap missing: {bootstrap}", file=sys.stderr)
+            raise SystemExit(1)
+        print("setting up the pywhats environment (a first run may take a minute)…", file=sys.stderr)
+        # stdout carries the interpreter path; stderr (pip progress) streams through.
+        result = subprocess.run(["bash", bootstrap], stdout=subprocess.PIPE, text=True)
+        lines = [ln.strip() for ln in (result.stdout or "").splitlines() if ln.strip()]
+        if result.returncode != 0 or not lines or not os.path.isfile(lines[-1]):
+            print("error: bootstrap failed — see messages above.", file=sys.stderr)
+            raise SystemExit(1)
+        os.environ["_WA_BOOTSTRAP_STAGE"] = "2"
+        os.execv(lines[-1], [lines[-1], script, *sys.argv[1:]])
+
+    print(
+        "error: pywhats still not importable after bootstrap. "
+        f"Remove {home / 'venv'} and re-run to rebuild.",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+
+
+_ensure_pywhats()
+
+# ---------------------------------------------------------------------------
+# Real CLI (runs only after pywhats is importable).
+# ---------------------------------------------------------------------------
+import argparse
+import asyncio
+import contextlib
+import json
+import mimetypes
+from typing import Any
+
+from pywhats import Client
+from pywhats.binary.jid import jid_to_str, parse_jid
+from pywhats.errors import PairingFailed
+
+# WhatsApp does not render image/gif ImageMessages (GIFs go out as video),
+# so only these are accepted by send-image.
+ALLOWED_IMAGE_TYPES = {"image/jpeg", "image/png", "image/webp"}
+MAX_IMAGE_BYTES = 16 * 1024 * 1024
+
+ALL_EVENTS = (
+    "qr",
+    "message",
+    "receipt",
+    "presence",
+    "chat_presence",
+    "history_sync",
+    "mute",
+    "pin",
+    "archive",
+    "contact",
+    "pushname",
+    "decrypt_error",
+    "logged_out",
+    "disconnected",
+    "paired",
+    "connected",
+)
+
+MAX_QR_WINDOWS = 5  # ~1 min each; unattended `pair` must not spin forever
+
+
+class SessionDead(Exception):
+    """Raised when the server logs the device out mid-command."""
+
+
+def _pywhats_home() -> pathlib.Path:
+    return pathlib.Path(os.environ.get("PYWHATS_HOME", pathlib.Path.home() / ".pywhats"))
+
+
+def _session_path(name: str) -> pathlib.Path:
+    home = _pywhats_home()
+    home.mkdir(parents=True, exist_ok=True)
+    return home / f"{name}.session"
+
+
+def _to_jid(target: str) -> Any:
+    """Accept a full JID, or a bare international number (leading '+' ok)."""
+    t = target.strip()
+    if "@" in t:
+        return parse_jid(t)
+    t = t.lstrip("+")
+    if not t.isdigit():
+        print(
+            f"error: invalid recipient {target!r} — use an international number "
+            "without '+' (e.g. 15550001234) or a full JID (...@s.whatsapp.net / ...@g.us)",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    return parse_jid(f"{t}@s.whatsapp.net")
+
+
+def _dm_jid(target: str) -> Any:
+    jid = _to_jid(target)
+    if jid.server == "g.us":
+        print("error: that is a group JID — use group-send / group-info instead.", file=sys.stderr)
+        raise SystemExit(2)
+    return jid
+
+
+def _group_jid(gid: str) -> Any:
+    jid = _to_jid(gid)
+    if jid.server != "g.us":
+        print(f"error: group commands need a full group JID ending in @g.us (got {gid!r}).", file=sys.stderr)
+        raise SystemExit(2)
+    return jid
+
+
+def _jid_field(value: Any) -> str | None:
+    if value is None:
+        return None
+    try:
+        return jid_to_str(value)
+    except Exception:  # noqa: BLE001
+        return str(value)
+
+
+def _pair_hint(session_name: str) -> str:
+    # NOTE: --session is a global option and must come BEFORE the subcommand.
+    return f"wa.py --session {session_name} pair"
+
+
+def _logged_out_message(session_name: str, reason: str) -> None:
+    print(
+        f"LOGGED OUT (reason={reason}) — the linked device was removed; the session "
+        f"is dead. Delete {_session_path(session_name)} (and .signal.db) and re-pair: "
+        f"{_pair_hint(session_name)}",
+        file=sys.stderr,
+    )
+
+
+def _delete_session(session: pathlib.Path) -> None:
+    for p in (session, pathlib.Path(str(session) + ".signal.db")):
+        with contextlib.suppress(OSError):
+            p.unlink()
+
+
+def _load_paired_client(session: pathlib.Path, session_name: str) -> Client:
+    """Build the one Client for this command; exit 1 with guidance if unusable."""
+    if not session.is_file():
+        print(f"error: no session at {session}. Run: {_pair_hint(session_name)}", file=sys.stderr)
+        raise SystemExit(1)
+    try:
+        client = Client(session_path=str(session))
+    except Exception as exc:  # noqa: BLE001  (store corrupt / bad permissions)
+        print(
+            f"error: could not load session {session}: {exc}\n"
+            f"Delete it and re-pair: {_pair_hint(session_name)}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1) from exc
+    dev = client.device
+    if dev is None or dev.jid is None:
+        print(f"error: session {session} is not paired. Run: {_pair_hint(session_name)}", file=sys.stderr)
+        raise SystemExit(1)
+    return client
+
+
+def _print_qr(qr_text: str, session: pathlib.Path) -> None:
+    print("\n=== Scan this in WhatsApp → Linked Devices → Link a Device ===\n")
+    png = pathlib.Path(str(session) + ".qr.png")
+    try:
+        import qrcode
+
+        qr = qrcode.QRCode(border=1)
+        qr.add_data(qr_text)
+        qr.make(fit=True)
+        with contextlib.suppress(Exception):  # PNG fallback for unscannable terminals
+            qr.make_image().save(png)
+            print(f"(QR also saved to {png})")
+        with contextlib.suppress(Exception):
+            qr.print_ascii(invert=True)
+            return
+        with contextlib.suppress(Exception):
+            qr.print_tty()
+            return
+    except Exception:  # noqa: BLE001
+        pass
+    print(qr_text)  # last resort: raw payload
+
+
+@contextlib.asynccontextmanager
+async def _connected(session: pathlib.Path, session_name: str):
+    """Shared command scaffold: one Client, logout watch, clean disconnect.
+
+    Yields ``(client, run)``. ``run(coro)`` races the operation against a
+    ``logged_out`` event so a dead session fails fast with guidance instead of
+    hanging until the ack timeout.
+    """
+    client = _load_paired_client(session, session_name)
+    logout = asyncio.Event()
+
+    @client.on("logged_out")
+    async def _on_logged_out(reason: str) -> None:
+        _logged_out_message(session_name, reason)
+        logout.set()
+
+    async def run(coro: Any) -> Any:
+        op = asyncio.ensure_future(coro)
+        watcher = asyncio.ensure_future(logout.wait())
+        done, _ = await asyncio.wait({op, watcher}, return_when=asyncio.FIRST_COMPLETED)
+        if op in done:
+            watcher.cancel()
+            return op.result()
+        op.cancel()
+        with contextlib.suppress(BaseException):
+            await op
+        raise SessionDead()
+
+    await client.connect()
+    try:
+        yield client, run
+    finally:
+        with contextlib.suppress(Exception):
+            await client.disconnect()
+
+
+# ---- subcommands ----------------------------------------------------------
+
+
+async def cmd_pair(session: pathlib.Path, session_name: str) -> int:
+    if session.is_file():
+        with contextlib.suppress(Exception):
+            dev = Client(session_path=str(session)).device
+            if dev is not None and dev.jid is not None:
+                print(f"already paired as {jid_to_str(dev.jid)} (session={session})")
+                print(
+                    "If this session is actually dead (device removed on the phone), "
+                    f"delete {session} and {session}.signal.db, then re-run pair."
+                )
+                return 0
+
+    client: Client | None = None
+    paired = asyncio.Event()
+    dead = asyncio.Event()
+    logout_reason: list[str] = []
+
+    for _attempt in range(MAX_QR_WINDOWS):
+        client = Client(session_path=str(session))
+        paired = asyncio.Event()  # fresh per attempt: no state leaks across retries
+        dead = asyncio.Event()
+        logout_reason = []
+
+        @client.on("qr")
+        async def on_qr(qr: str) -> None:
+            _print_qr(qr, session)
+
+        @client.on("paired")
+        async def on_paired(jid: object, _paired: asyncio.Event = paired) -> None:
+            print(f"PAIRED as {_jid_field(jid)}")
+            _paired.set()
+
+        @client.on("connected")
+        async def on_connected(_paired: asyncio.Event = paired) -> None:
+            print("connected.")
+            _paired.set()
+
+        @client.on("history_sync")
+        async def on_history(ev: object) -> None:
+            print(
+                f"history_sync: {ev.sync_type} "
+                f"({ev.conversation_count} chats, {ev.message_count} msgs)"
+            )
+
+        @client.on("logged_out")
+        async def on_logged_out(
+            reason: str,
+            _dead: asyncio.Event = dead,
+            _reasons: list[str] = logout_reason,
+        ) -> None:
+            _reasons.append(reason)
+            _dead.set()
+
+        @client.on("disconnected")
+        async def on_disconnected(_dead: asyncio.Event = dead) -> None:
+            _dead.set()
+
+        try:
+            await client.connect()
+        except PairingFailed:
+            print("QR window expired; regenerating a fresh QR — keep the phone ready.", file=sys.stderr)
+            with contextlib.suppress(Exception):
+                await client.disconnect()
+            continue
+        break
+    else:
+        print(
+            f"error: nothing scanned after {MAX_QR_WINDOWS} QR windows; "
+            "run pair again when the phone is ready.",
+            file=sys.stderr,
+        )
+        return 1
+
+    assert client is not None
+    try:
+        await asyncio.wait_for(paired.wait(), timeout=180)
+    except TimeoutError:
+        print("error: pairing timed out after 180s", file=sys.stderr)
+        with contextlib.suppress(Exception):
+            await client.disconnect()
+        return 1
+
+    dev = client.device
+    if dev is not None and dev.jid is not None:
+        print(f"device JID: {jid_to_str(dev.jid)}")
+    print("waiting ~8s for history-sync settle…")
+    dropped = False
+    try:
+        await asyncio.wait_for(dead.wait(), timeout=8)
+        dropped = True
+    except TimeoutError:
+        pass
+    with contextlib.suppress(Exception):
+        await client.disconnect()
+
+    if dropped and logout_reason:
+        # Definitive: the server logged the fresh device out (device-churn reaping).
+        _delete_session(session)
+        print(
+            f"\nERROR: WhatsApp logged this device out during settle (reason "
+            f"{logout_reason[-1]}) — the new device was reaped. The dead session "
+            "was deleted. This is account-state device churn, not a skill bug. To recover:\n"
+            "  1. Phone → WhatsApp → Linked Devices → remove ALL pywhats entries.\n"
+            "  2. Wait 15-20 min without pairing.\n"
+            f"  3. Run {_pair_hint(session_name)} once and don't unpair it.",
+            file=sys.stderr,
+        )
+        return 1
+    if dropped:
+        # Ambiguous: connection fell over without a logout — often just network.
+        print(
+            "\nWARNING: the connection dropped during settle without a logout. "
+            "The session was kept — test it with send-text. If commands report "
+            f"LOGGED OUT, delete {session} and follow the churn recovery steps "
+            "(remove linked devices, wait 15-20 min, pair once).",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"session saved: {session}")
+    print(
+        "note: WhatsApp sometimes removes a fresh device within ~1 min (churn). "
+        "If the next command reports LOGGED OUT, re-pair: " + _pair_hint(session_name)
+    )
+    return 0
+
+
+async def cmd_send_text(session: pathlib.Path, session_name: str, target: str, text: str) -> int:
+    chat = _dm_jid(target)
+    async with _connected(session, session_name) as (client, run):
+        msg = await run(client.send_text(chat, text))
+        print(msg.id)
+    return 0
+
+
+async def cmd_send_image(
+    session: pathlib.Path, session_name: str, target: str, image_path: str, caption: str
+) -> int:
+    chat = _dm_jid(target)
+    path = pathlib.Path(image_path)
+    if not path.is_file():
+        print(f"error: no such file: {image_path}", file=sys.stderr)
+        return 2
+    mimetype, _ = mimetypes.guess_type(path.name)
+    if mimetype not in ALLOWED_IMAGE_TYPES:
+        hint = " (WhatsApp renders GIFs as video, which pywhats 0.1.x cannot send)" if mimetype == "image/gif" else ""
+        print(
+            f"error: unsupported image type {mimetype or 'unknown'} for {path.name} — "
+            f"supported: jpg, jpeg, png, webp{hint}",
+            file=sys.stderr,
+        )
+        return 2
+    if path.stat().st_size > MAX_IMAGE_BYTES:
+        print(
+            f"error: {path.name} is {path.stat().st_size // (1024 * 1024)}MB; "
+            f"images are limited to {MAX_IMAGE_BYTES // (1024 * 1024)}MB",
+            file=sys.stderr,
+        )
+        return 2
+    data = path.read_bytes()
+    async with _connected(session, session_name) as (client, run):
+        msg = await run(client.send_image(chat, data, mimetype=mimetype, caption=caption))
+        print(msg.id)
+    return 0
+
+
+async def cmd_group_info(session: pathlib.Path, session_name: str, gid: str) -> int:
+    group = _group_jid(gid)
+    async with _connected(session, session_name) as (client, run):
+        info = await run(client.get_group_info(group))
+        print(
+            json.dumps(
+                {
+                    "subject": info.subject,
+                    "owner": _jid_field(info.owner),
+                    "announce": bool(info.announce),
+                    "locked": bool(info.locked),
+                    "participants": [
+                        {
+                            "jid": _jid_field(p.jid),
+                            "is_admin": bool(p.is_admin),
+                            "is_super_admin": bool(p.is_super_admin),
+                        }
+                        for p in info.participants
+                    ],
+                },
+                ensure_ascii=False,
+            )
+        )
+    return 0
+
+
+async def cmd_group_send(session: pathlib.Path, session_name: str, gid: str, text: str) -> int:
+    group = _group_jid(gid)
+    async with _connected(session, session_name) as (client, run):
+        info = await run(client.get_group_info(group))
+        msg = await run(client.send_group_text(group, text, [p.jid for p in info.participants]))
+        print(msg.id)
+    return 0
+
+
+async def cmd_mark_read(
+    session: pathlib.Path, session_name: str, chat: str, ids: list[str], sender: str | None
+) -> int:
+    chat_jid = _to_jid(chat)
+    sender_jid = _to_jid(sender) if sender else None
+    async with _connected(session, session_name) as (client, run):
+        await run(client.mark_read(chat_jid, ids, sender=sender_jid))
+        print(f"marked read: {ids}")
+    return 0
+
+
+async def cmd_presence(session: pathlib.Path, session_name: str, state: str) -> int:
+    async with _connected(session, session_name) as (client, run):
+        await run(client.send_presence(state))
+        print(f"presence={state}")
+    return 0
+
+
+async def cmd_typing(
+    session: pathlib.Path, session_name: str, target: str, state: str, media: str | None
+) -> int:
+    jid = _to_jid(target)
+    async with _connected(session, session_name) as (client, run):
+        await run(client.send_chat_presence(jid, state, media=media))
+        print(f"typing {state}" + (f" media={media}" if media else "") + f" → {target}")
+    return 0
+
+
+def _event_payload(name: str, args: tuple[Any, ...]) -> dict[str, Any]:
+    """One JSON-serializable dict per pywhats event (fields per pywhats.events)."""
+    out: dict[str, Any] = {"event": name}
+    if not args:
+        return out
+    if name == "qr":
+        out["qr"] = args[0]
+    elif name == "paired":
+        out["jid"] = _jid_field(args[0])
+    elif name == "logged_out":
+        out["reason"] = args[0]
+    elif name == "decrypt_error":
+        out["message_id"], out["reason"] = args[0], args[1] if len(args) > 1 else ""
+    elif name == "message":
+        m = args[0]
+        out.update(
+            id=m.id, chat=_jid_field(m.chat), sender=_jid_field(m.sender),
+            text=m.text, timestamp=int(m.timestamp), from_me=m.from_me,
+        )
+    elif name == "receipt":
+        r = args[0]
+        out.update(
+            from_jid=_jid_field(r.from_jid), message_ids=list(r.message_ids),
+            type=r.type, timestamp=int(r.timestamp), participant=_jid_field(r.participant),
+        )
+    elif name == "presence":
+        p = args[0]
+        out.update(
+            from_jid=_jid_field(p.from_jid), unavailable=p.unavailable,
+            last_seen=int(p.last_seen) if p.last_seen is not None else None,
+        )
+    elif name == "chat_presence":
+        p = args[0]
+        out.update(from_jid=_jid_field(p.from_jid), state=p.state, media=p.media)
+    elif name == "history_sync":
+        h = args[0]
+        out.update(
+            sync_type=h.sync_type, progress=int(h.progress), chunk_order=int(h.chunk_order),
+            conversation_count=int(h.conversation_count), message_count=int(h.message_count),
+            conversation_ids=list(h.conversation_ids),
+            pushnames=[list(p) if isinstance(p, (list, tuple)) else p for p in h.pushnames],
+        )
+    elif name == "mute":
+        e = args[0]
+        out.update(
+            jid=_jid_field(e.jid), muted=e.muted,
+            mute_end_timestamp=int(e.mute_end_timestamp), timestamp=int(e.timestamp),
+        )
+    elif name in ("pin", "archive"):
+        e = args[0]
+        key = "pinned" if name == "pin" else "archived"
+        out.update({"jid": _jid_field(e.jid), key: getattr(e, key), "timestamp": int(e.timestamp)})
+    elif name == "contact":
+        e = args[0]
+        out.update(
+            jid=_jid_field(e.jid), first_name=e.first_name,
+            full_name=e.full_name, timestamp=int(e.timestamp),
+        )
+    elif name == "pushname":
+        e = args[0]
+        out.update(name=e.name, timestamp=int(e.timestamp))
+    else:
+        out["payload"] = str(args[0])
+    return out
+
+
+async def cmd_listen(
+    session: pathlib.Path,
+    session_name: str,
+    auto_read: bool,
+    subscribe: list[str],
+    event_allow: set[str] | None,
+) -> int:
+    client = _load_paired_client(session, session_name)
+    logged_out: list[str] = []
+    tasks: set[asyncio.Task] = set()  # keep refs: unreferenced tasks can be GC'd
+
+    def _emit(name: str, *args: Any) -> None:
+        if event_allow is None or name in event_allow:
+            print(json.dumps(_event_payload(name, args), ensure_ascii=False), flush=True)
+
+    def _spawn(coro: Any) -> None:
+        t = asyncio.create_task(coro)
+        tasks.add(t)
+        t.add_done_callback(tasks.discard)
+
+    async def _auto_read(msg: Any) -> None:
+        # sender/participant is group-receipt semantics only; never for 1:1.
+        sender = msg.sender if msg.chat.server == "g.us" else None
+        try:
+            await client.mark_read(msg.chat, [msg.id], sender=sender)
+        except Exception as exc:  # noqa: BLE001 — surface, don't crash the stream
+            print(
+                json.dumps({"event": "error", "op": "mark_read", "id": msg.id, "error": str(exc)}),
+                flush=True,
+            )
+
+    def _forwarder(name: str):
+        async def handler(*args: Any) -> None:
+            _emit(name, *args)
+
+        return handler
+
+    for name in ALL_EVENTS:
+        if name not in ("message", "logged_out"):
+            client.on(name)(_forwarder(name))
+
+    @client.on("message")
+    async def on_message(msg: Any) -> None:
+        _emit("message", msg)
+        # Auto blue-tick via create_task (never bare-await client calls in a
+        # handler); skip our own messages and status broadcasts.
+        if auto_read and not msg.from_me and msg.chat.server != "broadcast":
+            _spawn(_auto_read(msg))
+
+    @client.on("logged_out")
+    async def on_logged_out(reason: str) -> None:
+        _emit("logged_out", reason)
+        logged_out.append(reason)
+        _logged_out_message(session_name, reason)
+
+    await client.connect()
+    if subscribe:
+        # Presence events only flow after announcing availability + subscribing.
+        await client.send_presence("available")
+        for target in subscribe:
+            await client.subscribe_presence(_to_jid(target))
+    try:
+        await client.wait_closed()
+    finally:
+        with contextlib.suppress(Exception):
+            await client.disconnect()
+    return 1 if logged_out else 0
+
+
+# ---- argparse -------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="wa.py",
+        description=(
+            "Portable WhatsApp CLI via pywhats (unofficial linked-device client). "
+            "Not the official WhatsApp Business/Cloud API. "
+            "Global options like --session go BEFORE the subcommand."
+        ),
+    )
+    parser.add_argument(
+        "--session",
+        default=os.environ.get("PYWHATS_SESSION", "default"),
+        help="Session name (file: $PYWHATS_HOME/<NAME>.session). "
+        "Default: env PYWHATS_SESSION or 'default'.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p = sub.add_parser("pair", help="Pair a new linked device via QR (ASCII + PNG)")
+    p.set_defaults(make=lambda a, s, n: cmd_pair(s, n))
+
+    p = sub.add_parser("send-text", help="Send a 1:1 text message")
+    p.add_argument("to", help="Phone (intl, '+' optional) or full JID")
+    p.add_argument("text", help="Message text")
+    p.set_defaults(make=lambda a, s, n: cmd_send_text(s, n, a.to, a.text))
+
+    p = sub.add_parser("send-image", help="Send an image (1:1; jpg/png/webp, ≤16MB)")
+    p.add_argument("to", help="Phone (intl, '+' optional) or full JID")
+    p.add_argument("path", help="Path to image file")
+    p.add_argument("--caption", default="", help="Optional caption")
+    p.set_defaults(make=lambda a, s, n: cmd_send_image(s, n, a.to, a.path, a.caption))
+
+    p = sub.add_parser("group-info", help="Fetch group metadata as JSON")
+    p.add_argument("gid", help="Group JID (required form: ...@g.us)")
+    p.set_defaults(make=lambda a, s, n: cmd_group_info(s, n, a.gid))
+
+    p = sub.add_parser("group-send", help="Send text to a group")
+    p.add_argument("gid", help="Group JID (required form: ...@g.us)")
+    p.add_argument("text", help="Message text")
+    p.set_defaults(make=lambda a, s, n: cmd_group_send(s, n, a.gid, a.text))
+
+    p = sub.add_parser("mark-read", help="Blue-tick one or more message ids")
+    p.add_argument("chat", help="Chat JID or phone number")
+    p.add_argument("ids", nargs="+", help="Message id(s)")
+    p.add_argument("--sender", default=None, help="Original sender JID (group receipts only)")
+    p.set_defaults(make=lambda a, s, n: cmd_mark_read(s, n, a.chat, a.ids, a.sender))
+
+    p = sub.add_parser("presence", help="Set global presence")
+    p.add_argument("state", choices=("available", "unavailable"))
+    p.set_defaults(make=lambda a, s, n: cmd_presence(s, n, a.state))
+
+    p = sub.add_parser("typing", help="Send typing/recording chat presence")
+    p.add_argument("to", help="Chat JID or phone number")
+    p.add_argument("state", choices=("composing", "paused"))
+    p.add_argument("--media", default=None, choices=("audio",), help="composing + media=audio = recording")
+    p.set_defaults(make=lambda a, s, n: cmd_typing(s, n, a.to, a.state, a.media))
+
+    p = sub.add_parser("listen", help="Long-running event stream (JSON lines on stdout)")
+    p.add_argument("--read", action="store_true", help="Auto mark-read inbound messages")
+    p.add_argument(
+        "--subscribe",
+        action="append",
+        default=[],
+        metavar="JID_OR_PHONE",
+        help="Subscribe to a peer's presence (repeatable); required for presence events, "
+        "also marks this device available",
+    )
+    p.add_argument(
+        "--events",
+        default=None,
+        help=f"Comma-separated event allowlist (default: all). Known: {','.join(ALL_EVENTS)}",
+    )
+    p.set_defaults(make=lambda a, s, n: cmd_listen(s, n, a.read, a.subscribe, a.event_allow))
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    session_name: str = args.session
+    session = _session_path(session_name)
+
+    if args.command == "listen":
+        args.event_allow = None
+        if args.events:
+            allow = {e.strip() for e in args.events.split(",") if e.strip()}
+            unknown = allow - set(ALL_EVENTS)
+            if unknown:
+                parser.error(
+                    f"unknown event(s): {', '.join(sorted(unknown))} "
+                    f"(known: {','.join(ALL_EVENTS)})"
+                )
+            args.event_allow = allow
+
+    try:
+        return asyncio.run(args.make(args, session, session_name))
+    except SessionDead:
+        return 1  # guidance already printed by the logged_out handler
+    except TimeoutError:
+        print(
+            "error: the server did not acknowledge in time — the connection may be "
+            f"dead. If this persists, re-pair: {_pair_hint(session_name)}",
+            file=sys.stderr,
+        )
+        return 1
+    except KeyboardInterrupt:
+        return 130  # clean disconnects already ran via finally blocks
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

New `whatsapp` skill built on the [pywhats](https://pypi.org/project/pywhats/) package (an unofficial WhatsApp multi-device client on PyPI, `pip install pywhats`). Drives a WhatsApp account as a linked companion device — **not** the official Business/Cloud API.

- **`scripts/wa.py`** — single dispatcher: `pair` (ASCII QR + PNG fallback, detects WhatsApp removing freshly linked devices and prints recovery steps), `send-text`, `send-image` (jpg/png/webp ≤16MB), `group-info`, `group-send`, `mark-read`, `presence`, `typing`, and `listen` (JSON-lines event stream with `--read` auto-receipts, `--subscribe` presence, `--events` filtering).
- **`scripts/_bootstrap.sh`** — managed venv at `$PYWHATS_HOME` (default `~/.pywhats`); selects a Python ≥3.11 interpreter (macOS system python3 is 3.9), pins `pywhats>=0.1.1,<0.2`, streams install progress. `wa.py` re-execs under it with staged loop protection.
- **Named sessions** for multi-account (`--session work`), clean exit codes (0/1/2/130), and fail-fast on dead sessions: every command races its operation against `logged_out` so an unlinked device exits immediately with re-pair guidance instead of hanging until the ack timeout.
- Docs: `SKILL.md` (agent-facing, mental model + deadlock rule), `README.md` (human quick start), `references/api.md` (pywhats method/event reference for custom scripts).

## Testing

- Live-verified end-to-end on real devices: pair (including a device-removal case correctly detected and reported), send-text and send-image delivered and visible on both sender and recipient devices, presence, typing, and listen capturing inbound messages and read receipts.
- Offline: full `--help` matrix, `--events` validation, invalid-recipient/mimetype/size guards, unpaired-session errors, clean-machine venv bootstrap from a 3.9-default PATH.